### PR TITLE
fix(prisma): resolve schema validation errors blocking setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ PORT=3000
 APP_URL=http://localhost:3000
 
 # ─── Cơ sở dữ liệu / Database ─────────────────────────────
-DATABASE_URL=postgresql://vierp:your-password@localhost:5432/vierp_dev
+# Must match docker-compose.yml credentials (POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB)
+DATABASE_URL=postgresql://erp:erp_dev_2026@localhost:5432/erp_dev
 
 # ─── Redis / Bộ nhớ đệm ───────────────────────────────────
 REDIS_URL=redis://localhost:6379

--- a/apps/HRM-unified/prisma/schema.prisma
+++ b/apps/HRM-unified/prisma/schema.prisma
@@ -340,6 +340,14 @@ model Tenant {
   internalApplications InternalApplication[]
   careerProfiles       CareerProfile[]
 
+  // Data Import & KPI
+  kpiPeriods           KPIPeriod[]
+  kpiScores            KPIScore[]
+  disciplinaryRecords  DisciplinaryRecord[]
+  salaryAdvances       SalaryAdvance[]
+  importSessions       ImportSession[]
+  systemSettings       SystemSetting[]
+
   @@map("tenants")
 }
 
@@ -443,6 +451,12 @@ model User {
 
   // Phase 7: Custom Roles
   customRoles UserCustomRole[]
+
+  // Data Import & KPI
+  createdKPIPeriods KPIPeriod[] @relation("KPICreator")
+  enteredKPIScores  KPIScore[]  @relation("KPIEnterer")
+  approvedAdvances  SalaryAdvance[] @relation("AdvanceApprover")
+  importedSessions  ImportSession[] @relation("ImportUser")
 
   @@unique([tenantId, email])
   @@map("users")
@@ -708,6 +722,11 @@ model Employee {
   jobPostingsAsHiringManager InternalJobPosting[]    @relation("PostingHiringManager")
   internalApplications       InternalApplication[]
   careerProfile              CareerProfile?
+
+  // Data Import & KPI
+  kpiScores           KPIScore[]
+  disciplinaryRecords DisciplinaryRecord[]
+  salaryAdvances      SalaryAdvance[]
 
   @@unique([tenantId, employeeCode])
   @@index([tenantId, status])
@@ -7204,7 +7223,7 @@ enum ImportType {
   POSITIONS
 }
 
-enum ImportStatus {
+enum ImportSessionStatus {
   DRY_RUN
   PREVIEWING
   EXECUTING
@@ -7214,10 +7233,10 @@ enum ImportStatus {
 }
 
 model ImportSession {
-  id            String       @id @default(cuid())
-  tenantId      String       @map("tenant_id")
+  id            String              @id @default(cuid())
+  tenantId      String              @map("tenant_id")
   type          ImportType
-  status        ImportStatus @default(DRY_RUN)
+  status        ImportSessionStatus @default(DRY_RUN)
   fileName      String       @map("file_name")
   fileSize      Int          @map("file_size")
   totalRows     Int          @map("total_rows")

--- a/apps/HRM/prisma/schema.prisma
+++ b/apps/HRM/prisma/schema.prisma
@@ -7,6 +7,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 // ═══════════════ ENUMS ═══════════════


### PR DESCRIPTION
## Summary

Fixes #1, #3 — All `npm run setup` / `make setup` commands fail at `db:generate` step due to Prisma schema validation errors.

## Root Causes & Fixes

### 1. Duplicate enum `ImportStatus` (HRM-unified)
Two enums with the same name but different values exist in `apps/HRM-unified/prisma/schema.prisma`:
- **Line 85**: `ImportStatus` with `PENDING, PROCESSING, COMPLETED, FAILED, ROLLED_BACK` (used by `ImportJob`)
- **Line 7207**: `ImportStatus` with `DRY_RUN, PREVIEWING, EXECUTING, COMPLETED, FAILED, ROLLED_BACK` (used by `ImportSession`)

**Fix**: Renamed the second enum to `ImportSessionStatus` since it serves a distinct purpose (data import session lifecycle vs. generic import job status). Updated the `ImportSession.status` field type accordingly.

### 2. Missing reverse relations (HRM-unified)
Models `KPIPeriod`, `KPIScore`, `DisciplinaryRecord`, `SalaryAdvance`, `ImportSession`, and `SystemSetting` reference `Tenant`, `User`, and `Employee` but the reverse relation arrays were never added to those parent models.

**Fix**: Added the missing reverse relation fields to `Tenant`, `User`, and `Employee` models.

### 3. Missing datasource URL (HRM)
`apps/HRM/prisma/schema.prisma` datasource block had no `url` field.

**Fix**: Added `url = env("DATABASE_URL")`.

### 4. DATABASE_URL mismatch (.env.example)
`.env.example` had `postgresql://vierp:your-password@localhost:5432/vierp_dev` but `docker-compose.yml` creates DB with user `erp`, password `erp_dev_2026`, database `erp_dev`.

**Fix**: Updated `.env.example` to `postgresql://erp:erp_dev_2026@localhost:5432/erp_dev`.

## Verification

Tested `npx prisma@5.22.0 validate` on all 12 schema files:

```
✅ apps/Accounting/prisma/schema.prisma
✅ apps/CRM/prisma/schema.prisma
✅ apps/Ecommerce/prisma/schema.prisma
✅ apps/HRM/prisma/schema.prisma
✅ apps/HRM-AI/lacviet-hr-phase5/prisma/schema.prisma
✅ apps/HRM-AI/prisma/schema.prisma
✅ apps/HRM-unified/lacviet-hr-phase5/prisma/schema.prisma
✅ apps/HRM-unified/prisma/schema.prisma
✅ apps/MRP/prisma/schema.prisma
✅ apps/OTB/backend/prisma/schema.prisma
✅ apps/TPM-api/prisma/schema.prisma
✅ apps/TPM-api-nestjs/prisma/schema.prisma
```

## Files Changed
- `apps/HRM-unified/prisma/schema.prisma` — enum rename + reverse relations
- `apps/HRM/prisma/schema.prisma` — datasource URL
- `.env.example` — DATABASE_URL credentials
